### PR TITLE
Much faster ID.compareTo

### DIFF
--- a/src/ID.js
+++ b/src/ID.js
@@ -87,11 +87,11 @@ define(['underscore', 'cryptojs', 'Utils'], function(_, CryptoJS, Utils) {
         throw new Error("Invalid argument.");
       }
 
-      var bytes = _.zip(this._bytes, id._bytes);
-      for (var i = 0; i < bytes.length; i++) {
-        if (bytes[i][0] < bytes[i][1]) {
+      for (var i = 0; i < this._bytes.length; i++) {
+
+        if (this._bytes[i] < id._bytes[i]) {
           return -1;
-        } else if (bytes[i][0] > bytes[i][1]) {
+        } else if (this._bytes[i] > id._bytes[i]) {
           return 1;
         }
       }


### PR DESCRIPTION
This passes all specs and is much faster than previous implementation.

![image](https://cloud.githubusercontent.com/assets/238667/3420921/2a3f457c-fecd-11e3-95f3-20f3ce8f81d4.png)

Total scripting time drops by a factor of 10, from 16 seconds to 1.85s. 

![image](https://cloud.githubusercontent.com/assets/238667/3420926/8627eede-fecd-11e3-9e2d-476857e5428d.png)
